### PR TITLE
linkMany.remove use $pullAll instead of $pull

### DIFF
--- a/lib/links/linkTypes/linkMany.js
+++ b/lib/links/linkTypes/linkMany.js
@@ -72,8 +72,8 @@ export default class LinkMany extends Link {
 
         // update the db
         let modifier = {
-            $pull: {
-                [root]: nested.length > 0 ? {[nested.join('.')]: {$in: _ids}} : {$in: _ids},
+            $pullAll: {
+                [root]: nested.length > 0 ? { [nested.join('.')]: _ids } : _ids,
             },
         };
 


### PR DESCRIPTION
Minimongo does not properly handle using $pull with $in and a list of strings.