### PR TITLE
Filter out undefined values from filterAssembledData()

### DIFF
--- a/lib/query/hypernova/assembler.js
+++ b/lib/query/hypernova/assembler.js
@@ -99,8 +99,11 @@ export default (childCollectionNode, { limit, skip, metaFilters }) => {
 };
 
 function filterAssembledData(data, { limit, skip }) {
-    if (limit && Array.isArray(data)) {
-        return data.slice(skip, limit);
+    if (Array.isArray(data)) {
+        data = data.filter(Boolean);
+        if (limit) {
+            return data.slice(skip, limit);
+        }
     }
 
     return data;


### PR DESCRIPTION
Having undefined values in parent.results is causing
all sorts of bugs in prepareForDelivery.js due to accessing
fields of "undefined" in node.results