### PR TITLE
Fix recursiveFetch to respect fetchOptions.scope on recursion

### DIFF
--- a/lib/query/lib/recursiveFetch.js
+++ b/lib/query/lib/recursiveFetch.js
@@ -44,7 +44,7 @@ function fetch(node, parentObject, fetchOptions = {}) {
 
     _.each(node.collectionNodes, collectionNode => {
         _.each(results, result => {
-            const collectionNodeResults = fetch(collectionNode, result);
+            const collectionNodeResults = fetch(collectionNode, result, fetchOptions);
             result[collectionNode.linkName] = collectionNodeResults;
             //delete result[node.linker.linkStorageField];
 


### PR DESCRIPTION
Currently fetchOptions are not passed recursively to child
collection nodes.

This is causing collisions across scoped queries on results
of child collection nodes.